### PR TITLE
Update HALO.cpp

### DIFF
--- a/reactions/src/HALO.cpp
+++ b/reactions/src/HALO.cpp
@@ -11,7 +11,7 @@
 #include <cstdlib>
 #include <sys/stat.h>
 #include <math.h>       /* pow */
-
+#include <chrono>
 
 #include "Common.h"
 #include "Quadrature.h"
@@ -357,9 +357,18 @@ double HALO::cvirial(double lgmass, double acol) const {
       while ( delta_col(lgmass)/mysig(pos_pt)-1.  < 0.){
           pos_pt = dis(gen);}
 
+      auto t1 = std::chrono::high_resolution_clock::now();
       while ( delta_col(lgmass)/mysig(neg_pt)-1. > 0.){
-          neg_pt = dis(gen);}
+        neg_pt = dis(gen);
 
+        auto t2 = std::chrono::high_resolution_clock::now();
+        double duration1 = std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count();
+        duration1 *= 1e-9;
+        if (duration1>1e-4) {
+          return g_de*myc0*pow(10.,-alpha*(lgmass-Mmin))*acol;
+                        }
+                      }
+    
        const double about_zero_mag = 1e-3;
       for (;;)
       {
@@ -404,9 +413,18 @@ double HALO::cvirial(double lgmass, double acol) const {
         while ( delta_colp(lgmass)/mysigp(pos_pt)-1.  < 0.){
             pos_pt = dis(gen);}
 
+        auto t1 = std::chrono::high_resolution_clock::now();
         while ( delta_colp(lgmass)/mysigp(neg_pt)-1. > 0.){
-            neg_pt = dis(gen);}
+          neg_pt = dis(gen);
 
+          auto t2 = std::chrono::high_resolution_clock::now();
+          double duration1 = std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count();
+          duration1 *= 1e-9;
+          if (duration1>1e-4) {
+            return myc0*pow(10.,-alpha*(lgmass-Mmin))*acol;
+                          }
+                        }
+      
          const double about_zero_mag = 1e-3;
         for (;;)
         {


### PR DESCRIPTION
Added timer to cvirial and cvirialp such that if they take longer than 1e-4 s to solve (average solve time is 1e-6s) then the function outputs cvirial with M_star= Mmin = 10^5 . This will be an approximate calculation and should only cause minimal errors in the reaction. This should only happen for sigma_8(z=0) < 0.5.