### PR TITLE
SPT with massive neutrinos

### DIFF
--- a/reactions/src/SPT.cpp
+++ b/reactions/src/SPT.cpp
@@ -801,7 +801,6 @@ double c[2] = {KMIN,-1.};
 double d[2] = {KMAX, 1.};
 switch (a) {
   case 0:
-    iow.initn_lin(vars[0], k, vars[1],vars[2], vars[3],vars[4]);
     tree = P_L(k);
     return tree;
   case 1:

--- a/reactions/src/SPT.cpp
+++ b/reactions/src/SPT.cpp
@@ -911,6 +911,10 @@ for(int zi = 0; zi<noz; zi++){
 }
 
 // BILL MOD
+// In its current form this function is broken as it requires P_L(k, z) at
+// multiple redshifts as input instead of only P_L(k,0) and this currently
+// can't be done.
+/*
 void SPT::ploop_init_nu(double ploopr[], double ploopp[], double redshifts[], int noz, double vars[], double k0){
   IOW iow;
 
@@ -994,7 +998,7 @@ for(int zi = 0; zi<noz; zi++){
     ploopp[zi] = tree + loopp;
 }
 }
-
+*/
 
 
 ////////////////////////////////////////////////

--- a/reactions/src/SPT.cpp
+++ b/reactions/src/SPT.cpp
@@ -632,6 +632,7 @@ real SPT::Lag_bias(int a, real k, real bias[]) const {
 
 /////// Numerical 1-loop spectra /////////////
 
+// BILL MOD
 static double ploopn2_mgdd( const PowerSpectrum& P_L, double vars[], double k, double r, double x){
   double kargs[4],kv[3],xv[3], p22,p13,d;
   IOW iow;
@@ -692,6 +693,7 @@ static double ploopn2_mgtt(const PowerSpectrum& P_L, double vars[], double k, do
 
 
 // pseudo 1-loop matter power spectrum (1812.05594)
+// BILL MOD
 static double ploopn2_mgdd_pseudo( const PowerSpectrum& P_L, double vars[], double k, double r, double x){
   double kargs[4],kv[3],xv[3], p22,p13,d;
   IOW iow;
@@ -715,6 +717,7 @@ static double ploopn2_mgdd_pseudo( const PowerSpectrum& P_L, double vars[], doub
 
 // Choose a {0,...,8}: P_linear, P_dd,P_dt, P_tt (MG), P_linear, P_dd,P_dt, P_tt (IDE), P_dd pseudo (see HALO.cpp)
 // vars: 0 =  scale factor, 1= omega_m(z=0), 2 = mg param , 3 = mg param, 4 = mg param,
+// BILL MOD
 double SPT::PLOOPn2(int a, double vars[], double k, double err) const{
   IOW iow;
 double loop, tree;
@@ -759,6 +762,7 @@ switch (a) {
 // vars:  1 = omega0,  2 = mg param
 // k0 - scale at which to compute Spectra
 
+// BILL MOD
 void SPT::ploop_init(double ploopr[], double ploopp[], double redshifts[], int noz, double vars[], double k0){
   IOW iow;
 

--- a/reactions/src/SPT.cpp
+++ b/reactions/src/SPT.cpp
@@ -650,7 +650,7 @@ static double ploopn2_mgdd( const PowerSpectrum& P_L, double vars[], double k, d
         p22 = pow2(F2_nk);
         p13 = F1_nk*F3_nk;
 
-    return pow2(r)*2.*P_L(k*r)*(P_L(kargs[0])*p22 + 3.*P_L(k)*p13);
+    return pow2(r)*2.*(P_L(k*r)/pow2(F1p_nk))*( (P_L(kargs[0])/pow2(F1kmp_nk))*p22 + 3.*(P_L(k)/pow2(F1_nk))*p13 ); //return pow2(r)*2.*P_L(k*r)*(P_L(kargs[0])*p22 + 3.*P_L(k)*p13);
 }
 
 static double ploopn2_mgdt( const PowerSpectrum& P_L, double vars[], double k, double r, double x){
@@ -711,7 +711,7 @@ static double ploopn2_mgdd_pseudo( const PowerSpectrum& P_L, double vars[], doub
         p22 = pow2(F2_nk);
         p13 = F1_nk*F3_nk;
 
-    return pow2(r)*2.*P_L(k*r)*(P_L(kargs[0])*p22 + 3.*P_L(k)*p13);
+    return pow2(r)*2.*(P_L(k*r)/pow2(F1p_nk))*( (P_L(kargs[0])/pow2(F1kmp_nk))*p22 + 3.*(P_L(k)/pow2(F1_nk))*p13 ); //return pow2(r)*2.*P_L(k*r)*(P_L(kargs[0])*p22 + 3.*P_L(k)*p13);
 }
 
 
@@ -733,7 +733,7 @@ switch (a) {
     return tree;
   case 1:
     loop = prefac*Integrate<2>(bind(ploopn2_mgdd,cref(P_L),vars,k,std::placeholders::_1,std::placeholders::_2), c, d, err);
-    tree = pow2(F1_nk/dnorm_spt)*P_L(k);
+    tree = P_L(k); //pow2(F1_nk/dnorm_spt)*P_L(k);
     return loop+tree;
   case 2:
     loop = prefac*Integrate<2>(bind(ploopn2_mgdt,cref(P_L),vars,k,std::placeholders::_1,std::placeholders::_2), c, d, err,1e-2);
@@ -745,7 +745,7 @@ switch (a) {
     return loop+tree;
   case 8:
     loop = prefac*Integrate<2>(bind(ploopn2_mgdd_pseudo,cref(P_L),vars,k,std::placeholders::_1,std::placeholders::_2), c, d, err);
-    tree = pow2(F1_nk/dnorm_spt)*P_L(k);
+    tree = P_L(k); //pow2(F1_nk/dnorm_spt)*P_L(k);
     return loop+tree;
     default:
     warning("SPT: invalid indices, a = %d \n", a);

--- a/reactions/src/SPT.cpp
+++ b/reactions/src/SPT.cpp
@@ -721,7 +721,7 @@ static double ploopn2_mgdd_pseudo( const PowerSpectrum& P_L, double vars[], doub
 double SPT::PLOOPn2(int a, double vars[], double k, double err) const{
   IOW iow;
 double loop, tree;
-double prefac = k*k*k/(4*M_PI*M_PI)/pow4(dnorm_spt);
+double prefac = k*k*k/(4*M_PI*M_PI);
 real KMAX = QMAXp/k;
 real KMIN = QMINp/k;
 double c[2] = {KMIN,-1.};
@@ -840,8 +840,8 @@ for(int zi = 0; zi<noz; zi++){
 // assign values of 1-loop spectra to arrays
   for(int zi=0; zi<noz; zi++){
     double tree = P_L(k0);
-    double loop = pow3(k0)/(4*M_PI*M_PI) * res[zi]; // BILL
-    double loopp = pow3(k0)/(4*M_PI*M_PI) * resp[zi]; // BILL
+    double loop = pow3(k0)/(4*M_PI*M_PI) * res[zi];
+    double loopp = pow3(k0)/(4*M_PI*M_PI) * resp[zi];
     ploopr[zi] = tree + loop;
     ploopp[zi] = tree + loopp;
 }

--- a/reactions/src/SPT.h
+++ b/reactions/src/SPT.h
@@ -35,11 +35,13 @@ public:
   // values of a :
   // 1: P_dd, 2: P_dt , 3: P_tt for mg,
   // 4: P_dd, 5: P_dt , 6: P_tt for interacting DE of
-  // vars: 0:scale factor , 1: omega_0, 2: mg1, 3 : mg2 , 4 : mg3 
+  // vars: 0:scale factor , 1: omega_0, 2: mg1, 3 : mg2 , 4 : mg3
   real PLOOPn2(int a, double vars[], double k, double err) const;
+  real PLOOPn2_nu(int a, double vars[], double k, double err) const;
 
   // initialise p_loop values over redshifts[] at k=k0 for k_star in reaction code (HALO.cpp)
   void ploop_init(double ploopr[], double ploopp[], double redshifts[], int noz, double vars[], double k0);
+  void ploop_init_nu(double ploopr[], double ploopp[], double redshifts[], int noz, double vars[], double k0);
 
   // halo fit coefficient initialisation
   void phinit(double scalef, double omega0) const;

--- a/reactions/src/SPT.h
+++ b/reactions/src/SPT.h
@@ -41,7 +41,7 @@ public:
 
   // initialise p_loop values over redshifts[] at k=k0 for k_star in reaction code (HALO.cpp)
   void ploop_init(double ploopr[], double ploopp[], double redshifts[], int noz, double vars[], double k0);
-  void ploop_init_nu(double ploopr[], double ploopp[], double redshifts[], int noz, double vars[], double k0);
+  // void ploop_init_nu(double ploopr[], double ploopp[], double redshifts[], int noz, double vars[], double k0); // This function is currently broken, see SPT.cpp for explanation.
 
   // halo fit coefficient initialisation
   void phinit(double scalef, double omega0) const;

--- a/reactions/src/SpecialFunctions.cpp
+++ b/reactions/src/SpecialFunctions.cpp
@@ -400,6 +400,7 @@ struct param_type3 {
 
 
 // system of equations for modified gravity (1606.02520 )
+
 int funcn1(double a, const double G[], double F[], void *params)
 {
 	param_type3 p = *(param_type3 *)(params);
@@ -727,7 +728,8 @@ void IOW::initn2_pseudo(double A, double k[], double x[], double kargs[], double
 
 
 // Used to store kernel values for various redshifts for lensing computation (see HALO.cpp and SPT.cpp - react_init and PLOOPn2 functions respectively)
-void IOW::initn3(double redshifts[], int noz, double k[], double x[], double kargs[], double omega0, double par1, double par2, double par3,double mykernelarray[][12]){
+// BILL MOD
+void IOW::initn3(double redshifts[], int noz, double k[], double x[], double kargs[], double omega0, double par1, double par2, double par3,double mykernelarray[][20]){
 				if(redshifts[0]>2.5){
 					warning("SpecialFunctions: highest z unstable, should be 2.5 or less: z max = %e \n", redshifts[0]);
 				}
@@ -776,6 +778,15 @@ void IOW::initn3(double redshifts[], int noz, double k[], double x[], double kar
                         mykernelarray[0][10]=Gp[12];
                         mykernelarray[0][11]=Gp[13];
 
+												mykernelarray[0][12]=G[2];
+												mykernelarray[0][13]=G[3];
+												mykernelarray[0][14]=G[4];
+												mykernelarray[0][15]=G[5];
+												mykernelarray[0][16]=Gp[2];
+												mykernelarray[0][17]=Gp[3];
+												mykernelarray[0][18]=Gp[4];
+												mykernelarray[0][19]=Gp[5];
+
 
 
 double ai,af,aip,afp;
@@ -792,26 +803,39 @@ double ai,af,aip,afp;
 
                          /*1st order */
                         //F1(k;a), G1(k;a)
-		        						mykernelarray[i][0]=G[0];
+		        						mykernelarray[i][0]=G[0]; //F1(k)
                         mykernelarray[i][1]=G[1];
 
                        /*2nd order*/
 											 //F2/G2(p,k-p) (P22
-												mykernelarray[i][2]=G[6];
+												mykernelarray[i][2]=G[6]; //F2
                         mykernelarray[i][3]=G[7];
 
                         /* 3rd order */
                         //F3/G3[k,p,-p]
-												mykernelarray[i][4]=G[12];
+												mykernelarray[i][4]=G[12]; //F3
                         mykernelarray[i][5]=G[13];
 
                        /*same for pseudo */
-											 mykernelarray[i][6]=Gp[0];
+											 mykernelarray[i][6]=Gp[0]; //F1_noscr(k)
                         mykernelarray[i][7]=Gp[1];
-                        mykernelarray[i][8]=Gp[6];
+                        mykernelarray[i][8]=Gp[6]; //F2_noscr
                         mykernelarray[i][9]=Gp[7];
-                        mykernelarray[i][10]=Gp[12];
+                        mykernelarray[i][10]=Gp[12]; //F3_noscr
                         mykernelarray[i][11]=Gp[13];
+
+												/* Extra 1st order needed for P_L(k, z) instead of P_L(k, 0) input */
+												mykernelarray[i][12]=G[2]; //F1(k-p)
+												mykernelarray[i][13]=G[3]; //G1(k-p)
+
+												mykernelarray[i][14]=G[4]; //F1(p)
+												mykernelarray[i][15]=G[5]; //G1(p)
+
+												mykernelarray[i][16]=Gp[2]; //F1_noscr(k-p)
+												mykernelarray[i][17]=Gp[3]; //G1_noscr(k-p)
+
+												mykernelarray[i][18]=Gp[4]; //F1_noscr(p)
+												mykernelarray[i][19]=Gp[5]; //G1_noscr(p)
 
 		}
 		// free memory

--- a/reactions/src/SpecialFunctions.h
+++ b/reactions/src/SpecialFunctions.h
@@ -133,7 +133,7 @@ public:
     void initnorm(double vars[]); // wCDM and LCDM power spectrum normalisation  - roughly the same as above function but with no MG and with dark energy. It solves at a=1 to normalise general spectrum as well solves with LCDM at given a
     void initn2(double A, double k[], double x[], double kargs[], double omega0, double par1, double par2, double par3); // 1-loop kernel solver
     void initn2_pseudo(double A, double k[], double x[], double kargs[], double omega0, double par1, double par2, double par3); // 1-loop pseudo spectrum kernel solver
-    void initn3(double redshifts[], int noz, double k[], double x[], double kargs[], double omega0, double par1, double par2, double par3, double mykernelarray[][12]); // 1-loop kernel (real and pseudo) solver for array of redshifts -- used in reaction for lensing
+    void initn3(double redshifts[], int noz, double k[], double x[], double kargs[], double omega0, double par1, double par2, double par3, double mykernelarray[][20]); // 1-loop kernel (real and pseudo) solver for array of redshifts -- used in reaction for lensing
     void initn_rsd(double A, double k[], double x[], double kargs[], double omega0, double par1, double par2, double par3); // 1-loop TNS solver (also solves for ABC correction term kernels)
 
 };


### PR DESCRIPTION
This PR implements massive neutrinos in the SPT computations necessary to compute the reaction. 

The method used to implement massive neutrinos in SPT follows Section 2.3 of arXiv:1902.10692 -- first the 1-loop terms are rewritten to take P_L(k, z) as input instead of P_L(k, 0); secondly the effect of massive neutrinos is only included in P_L, such that the PT kernels are unchanged.

Unless we want to change the input from P_L(k, 0) to P_L(k, z) throughout, it would be good to add some sort of flag for massive neutrinos that switches the code to use these new SPT functions and reminds the user to supply P_L(k, z) instead of (or as well as) P_L(k, 0).

Currently, the implementation here is for density-density terms only, but it is easy to apply the same method to density-velocity and velocity-velocity terms.